### PR TITLE
Purge types from styled component prop functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
     "react/prop-types": "off",
     "@typescript-eslint/interface-name-prefix": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
   },
   settings: {
     react: {

--- a/src/components/alerts/Alert.tsx
+++ b/src/components/alerts/Alert.tsx
@@ -49,8 +49,8 @@ const Alert = ({ type = 'info', children }: AlertProps): JSX.Element => {
 export default Alert;
 
 const StyledBox = styled.div<{ backgroundColor: string; borderColor: string }>`
-  background-color: ${({ backgroundColor }): string => backgroundColor};
-  border: 1px solid ${({ borderColor }): string => borderColor};
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  border: 1px solid ${({ borderColor }) => borderColor};
   padding: 1em;
   border-radius: 3px;
 `;

--- a/src/components/alerts/Alert.tsx
+++ b/src/components/alerts/Alert.tsx
@@ -7,7 +7,7 @@ interface AlertProps {
   children: React.ReactNode;
 }
 
-const Alert = ({ type = 'info', children }: AlertProps): JSX.Element => {
+const Alert = ({ type = 'info', children }: AlertProps) => {
   let color: string;
   let bordercolor: string;
 

--- a/src/components/breakpoints/Breakpoints.tsx
+++ b/src/components/breakpoints/Breakpoints.tsx
@@ -24,7 +24,7 @@ const StyledBreakpoints = styled.div`
   }
 `;
 
-const Breakpoints = ({ children, ...props }: BreakpointsProps): JSX.Element => {
+const Breakpoints = ({ children, ...props }: BreakpointsProps) => {
   return <StyledBreakpoints {...props}>{children}</StyledBreakpoints>;
 };
 

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -52,7 +52,7 @@ const Button = ({
   variant = 'normal',
   disabled = false,
   ...props
-}: ButtonProps): JSX.Element => {
+}: ButtonProps) => {
   let mainColor: string = colors.primary;
   switch (color) {
     case 'secondary': {

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { StyledComponentProps } from 'styled-components';
+import styled, { css, StyledComponentProps } from 'styled-components';
 import { colors } from 'common/colors';
 
 interface ButtonProps extends StyledComponentProps<'button', any, any, any> {
@@ -16,8 +16,8 @@ interface StyledButtonProps {
 
 const StyledButton = styled.button<StyledButtonProps>`
   appearance: none;
-  background: ${(props): string => props.color};
-  border: 2px solid ${(props): string => props.color};
+  background: ${(props) => props.color};
+  border: 2px solid ${(props) => props.color};
   color: ${colors.white};
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   border-radius: 3px;
@@ -36,13 +36,13 @@ const StyledButton = styled.button<StyledButtonProps>`
     cursor: not-allowed;
   }
 
-  ${(props): string | false =>
+  ${(props) =>
     props.variant == 'outline' &&
-    `
-    background: transparent;
-    border: 2px solid ${props.color};
-    color: ${props.color};
-  `}
+    css`
+      background: transparent;
+      border: 2px solid ${props.color};
+      color: ${props.color};
+    `}
 `;
 
 const Button = ({

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -16,7 +16,7 @@ const StyledCard = styled.div`
   padding: 1rem;
 `;
 
-const Card = ({ children, ...props }: CardProps): JSX.Element => {
+const Card = ({ children, ...props }: CardProps) => {
   return <StyledCard {...props}>{children}</StyledCard>;
 };
 

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { colors } from 'common/colors';
 
 interface CheckboxProps {
@@ -43,7 +43,7 @@ const CheckboxLabel = styled.label<{ disabled?: boolean }>`
   &:hover {
     color: ${colors.primaryDarken45};
   }
-  ${({ disabled }): FlattenSimpleInterpolation | undefined | false => disabled && CheckboxLabelDisabled};
+  ${({ disabled }) => disabled && CheckboxLabelDisabled};
 `;
 
 const CheckboxCommon = css`
@@ -61,7 +61,7 @@ const HiddenCheckbox = styled.input.attrs({ type: 'checkbox' })`
 const StyledCheckbox = styled.div<{ error?: boolean }>`
   ${CheckboxCommon}
   display: inline-block;
-  border: 1px solid ${({ error }): string => (error ? colors.error : colors.grayLighten90)};
+  border: 1px solid ${({ error }) => (error ? colors.error : colors.grayLighten90)};
   background: #fff;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
   transition: background-color 0.2s ease-in, border-color 0.2s;

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -10,9 +10,9 @@ interface CheckboxProps {
   error?: boolean;
 }
 
-const Checkbox = ({ label, isChecked, onCheck, disabled, error }: CheckboxProps): JSX.Element => {
+const Checkbox = ({ label, isChecked, onCheck, disabled, error }: CheckboxProps) => {
   return (
-    <CheckboxLabel onChange={(): void => onCheck(!isChecked)} disabled={disabled}>
+    <CheckboxLabel onChange={() => onCheck(!isChecked)} disabled={disabled}>
       <HiddenCheckbox checked={isChecked} disabled={disabled} />
       <StyledCheckbox tabIndex={0} error={error} />
       <span>{label}</span>

--- a/src/components/colors/Colors.tsx
+++ b/src/components/colors/Colors.tsx
@@ -26,7 +26,7 @@ const StyledColor = styled.div<{ color: ColorStrings; darkText: boolean }>`
   }
 `;
 
-const ColorSwatch = ({ color, darkText = false }: ColorSwatchProps): JSX.Element => {
+const ColorSwatch = ({ color, darkText = false }: ColorSwatchProps) => {
   return (
     <StyledColor color={color} darkText={darkText}>
       <span>{color}</span>

--- a/src/components/colors/Colors.tsx
+++ b/src/components/colors/Colors.tsx
@@ -14,15 +14,15 @@ const StyledColor = styled.div<{ color: ColorStrings; darkText: boolean }>`
   justify-content: space-between;
   flex-wrap: wrap;
   line-height: 1.5;
-  background: ${({ color }): string => colors[color]};
-  border: 2px solid ${({ color }): string => colors[color]};
-  color: ${({ darkText }): string => (darkText ? colors.black : colors.white)};
+  background: ${({ color }) => colors[color]};
+  border: 2px solid ${({ color }) => colors[color]};
+  color: ${({ darkText }) => (darkText ? colors.black : colors.white)};
   width: 100%;
   padding: 1rem;
   transition: background 0.2s ease-out, color 0.2s;
 
   &:hover {
-    border-color: ${({ darkText }): string => (darkText ? colors.black : colors.white)};
+    border-color: ${({ darkText }) => (darkText ? colors.black : colors.white)};
   }
 `;
 

--- a/src/components/eventCard/EventCard.tsx
+++ b/src/components/eventCard/EventCard.tsx
@@ -33,7 +33,7 @@ const EventInfo = styled.div`
 
 const ColorCodeIndicator = styled.span<{ color?: string }>`
   display: inline-block;
-  background: ${({ color }): string => color || colors.primary};
+  background: ${({ color }) => color || colors.primary};
   width: 7px;
   min-height: calc(4rem - 20px);
   margin: 10px 0;
@@ -64,7 +64,7 @@ const Picture = styled.img<{ hidden: boolean }>`
 `;
 
 const CategoryInfo = styled.h2<{ color?: string; hidden: boolean }>`
-  background: ${({ color }): string => color || colors.primary};
+  background: ${({ color }) => color || colors.primary};
   color: #fff;
   margin: 0;
   border-top-left-radius: 3px;

--- a/src/components/eventCard/EventCard.tsx
+++ b/src/components/eventCard/EventCard.tsx
@@ -79,15 +79,7 @@ const CategoryInfo = styled.h2<{ color?: string; hidden: boolean }>`
   }
 `;
 
-const EventCard = ({
-  eventName,
-  eventColor,
-  date,
-  attending,
-  imgSrc = '',
-  isLargeEvent,
-  category,
-}: ICard): JSX.Element => (
+const EventCard = ({ eventName, eventColor, date, attending, imgSrc = '', isLargeEvent, category }: ICard) => (
   <CardContainer>
     <CategoryInfo color={eventColor} hidden={!isLargeEvent}>
       {category}

--- a/src/components/icons/CircleCheckmark.tsx
+++ b/src/components/icons/CircleCheckmark.tsx
@@ -15,7 +15,7 @@ const IconWrapper = styled.div`
   display: flex;
 `;
 
-const CircleCheckmark = ({ color = '#1e8449', size = '100px' }: Props): JSX.Element => (
+const CircleCheckmark = ({ color = '#1e8449', size = '100px' }: Props) => (
   <IconWrapper>
     <CircleContainer viewBox="0 0 100 100" size={size}>
       <circle cx="50" cy="50" r="50" fill={color} />

--- a/src/components/icons/CircleCheckmark.tsx
+++ b/src/components/icons/CircleCheckmark.tsx
@@ -7,11 +7,11 @@ export interface Props {
 }
 
 const CircleContainer = styled.svg<{ size?: string }>`
-  height: ${({ size }): string | undefined => size};
-  width: ${({ size }): string | undefined => size};
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
 `;
 
-const IconWrapper = styled.div<{}>`
+const IconWrapper = styled.div`
   display: flex;
 `;
 

--- a/src/components/icons/CircleCross.tsx
+++ b/src/components/icons/CircleCross.tsx
@@ -15,7 +15,7 @@ const IconWrapper = styled.div`
   display: flex;
 `;
 
-const CircleCross = ({ color = '#eb5757', size = '100px' }: Props): JSX.Element => (
+const CircleCross = ({ color = '#eb5757', size = '100px' }: Props) => (
   <IconWrapper>
     <CircleContainer viewBox="0 0 100 100" size={size}>
       <circle cx="50" cy="50" r="50" fill={color} />

--- a/src/components/icons/CircleCross.tsx
+++ b/src/components/icons/CircleCross.tsx
@@ -7,11 +7,11 @@ export interface Props {
 }
 
 const CircleContainer = styled.svg<{ size?: string }>`
-  height: ${({ size }): string | undefined => size};
-  width: ${({ size }): string | undefined => size};
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
 `;
 
-const IconWrapper = styled.div<{}>`
+const IconWrapper = styled.div`
   display: flex;
 `;
 

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { StyledComponentProps } from 'styled-components';
+import styled, { css, StyledComponentProps } from 'styled-components';
 import { colors } from 'common/colors';
 
 interface LinkProps extends StyledComponentProps<'a', any, any, any> {
@@ -27,9 +27,9 @@ const StyledLink = styled.a<StyledLinkProps>`
     bottom: 0;
     left: 0;
     transition: transform 0.1s, color 0.1s;
-    ${(props): string | false | undefined =>
+    ${(props) =>
       !props.underline &&
-      `
+      css`
         transform: scaleX(0);
       `}
   }

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -46,7 +46,7 @@ const StyledLink = styled.a<StyledLinkProps>`
   }
 `;
 
-const Link = ({ href, underline = false, children }: LinkProps): JSX.Element => {
+const Link = ({ href, underline = false, children }: LinkProps) => {
   return (
     <StyledLink href={href} underline={underline}>
       {children}

--- a/src/components/logo/LightningO.tsx
+++ b/src/components/logo/LightningO.tsx
@@ -18,11 +18,7 @@ const OSvg = styled.svg<SvgProps>`
   height: ${({ height }) => height}px;
 `;
 
-const LightningO = ({
-  size = 300,
-  oColor = colors.officialBlue,
-  lightningColor = colors.officialOrange,
-}: OwnProps): JSX.Element => {
+const LightningO = ({ size = 300, oColor = colors.officialBlue, lightningColor = colors.officialOrange }: OwnProps) => {
   const proportion = 615 / 445;
   return (
     <OSvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 615 445" width={size} height={size / proportion}>

--- a/src/components/logo/LightningO.tsx
+++ b/src/components/logo/LightningO.tsx
@@ -14,8 +14,8 @@ interface OwnProps {
 }
 
 const OSvg = styled.svg<SvgProps>`
-  ${({ width }): string => width + 'px;'}
-  ${({ height }): string => height + 'px;'}
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
 `;
 
 const LightningO = ({

--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { colors } from 'common/colors';
 
 interface LogoProps {
@@ -13,7 +13,11 @@ type OwnProps = Partial<LogoProps>;
 const proportion = 59 / 239;
 
 export const FullLogo = styled.svg<LogoProps>`
-  ${({ size }): string => 'width: ' + size / proportion + 'px; height: ' + size + 'px;'};
+  ${({ size }) =>
+    css`
+      width: ${size / proportion}px;
+      height: ${size}px;
+    `};
 `;
 
 const Logo = ({

--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -20,11 +20,7 @@ export const FullLogo = styled.svg<LogoProps>`
     `};
 `;
 
-const Logo = ({
-  textColor = colors.officialBlue,
-  lightningColor = colors.officialOrange,
-  size = 59,
-}: OwnProps): JSX.Element => {
+const Logo = ({ textColor = colors.officialBlue, lightningColor = colors.officialOrange, size = 59 }: OwnProps) => {
   return (
     <FullLogo xmlns="http://www.w3.org/2000/svg" size={size} viewBox="0 0 239 59">
       <defs />

--- a/src/components/logo/StaticLogo.tsx
+++ b/src/components/logo/StaticLogo.tsx
@@ -17,7 +17,7 @@ const StaticLogo = ({
   primaryColor = colors.officialBlue,
   secondaryColor = colors.officialOrange,
   size = '100px',
-}: Props): JSX.Element => (
+}: Props) => (
   <Logo size={size} viewBox="0 0 141 112" fill="none">
     <g clipPath="url(#clip0)">
       <path

--- a/src/components/logo/StaticLogo.tsx
+++ b/src/components/logo/StaticLogo.tsx
@@ -9,8 +9,8 @@ export interface Props {
 }
 
 const Logo = styled.svg<{ size: string }>`
-  height: ${({ size }): string => size};
-  width: ${({ size }): string => size};
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
 `;
 
 const StaticLogo = ({

--- a/src/components/logo/StaticSpinnerLogo.tsx
+++ b/src/components/logo/StaticSpinnerLogo.tsx
@@ -10,8 +10,8 @@ export interface SpinnerLogoProps {
 
 const SpinnerContainer = styled.section<{ size: string }>`
   position: relative;
-  height: ${({ size }): string => size};
-  width: ${({ size }): string => size};
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
 `;
 
 const SpinningCircle = styled.svg`

--- a/src/components/logo/StaticSpinnerLogo.tsx
+++ b/src/components/logo/StaticSpinnerLogo.tsx
@@ -27,7 +27,7 @@ const StaticSpinnerLogo = ({
   primaryColor = colors.officialBlue,
   secondaryColor = colors.officialOrange,
   spinnerSize = '100px',
-}: SpinnerLogoProps): JSX.Element => (
+}: SpinnerLogoProps) => (
   <SpinnerContainer size={spinnerSize}>
     <SpinningCircle viewBox="0 0 506 400" fill="none">
       <circle

--- a/src/components/radio/Radio.tsx
+++ b/src/components/radio/Radio.tsx
@@ -9,16 +9,14 @@ interface RadioProps {
   error?: boolean;
 }
 
-const Radio = ({ labels, groupName, disabled, error }: RadioProps): JSX.Element => {
-  const radios = labels.map(
-    (label, index): JSX.Element => (
-      <RadioLabel key={index} disabled={disabled}>
-        <HiddenRadio name={groupName} disabled={disabled} />
-        <StyledRadio tabIndex={0} error={error} />
-        {label}
-      </RadioLabel>
-    )
-  );
+const Radio = ({ labels, groupName, disabled, error }: RadioProps) => {
+  const radios = labels.map((label, index) => (
+    <RadioLabel key={index} disabled={disabled}>
+      <HiddenRadio name={groupName} disabled={disabled} />
+      <StyledRadio tabIndex={0} error={error} />
+      {label}
+    </RadioLabel>
+  ));
   return <RadioGroup error={error}>{radios}</RadioGroup>;
 };
 
@@ -35,7 +33,7 @@ const RadioGroup = styled.div<{ error?: boolean }>`
     margin-top: 0.5rem;
   }
 
-  ${({ error }) => Boolean(error) && RadioGroupError};
+  ${({ error }) => error && RadioGroupError};
 `;
 
 const RadioLabelDisabled = css`
@@ -59,7 +57,7 @@ const RadioLabel = styled.label<{ disabled?: boolean }>`
     color: ${colors.primary};
   }
 
-  ${({ disabled }) => Boolean(disabled) && RadioLabelDisabled};
+  ${({ disabled }) => disabled && RadioLabelDisabled};
 `;
 
 const HiddenRadioCommon = css`

--- a/src/components/radio/Radio.tsx
+++ b/src/components/radio/Radio.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { colors } from 'common/colors';
-import { ExternalCSS } from 'common/types';
 
 interface RadioProps {
   labels: string[];
@@ -36,7 +35,7 @@ const RadioGroup = styled.div<{ error?: boolean }>`
     margin-top: 0.5rem;
   }
 
-  ${({ error }): ExternalCSS => Boolean(error) && RadioGroupError};
+  ${({ error }) => Boolean(error) && RadioGroupError};
 `;
 
 const RadioLabelDisabled = css`
@@ -60,7 +59,7 @@ const RadioLabel = styled.label<{ disabled?: boolean }>`
     color: ${colors.primary};
   }
 
-  ${({ disabled }): ExternalCSS => Boolean(disabled) && RadioLabelDisabled};
+  ${({ disabled }) => Boolean(disabled) && RadioLabelDisabled};
 `;
 
 const HiddenRadioCommon = css`
@@ -80,7 +79,7 @@ const HiddenRadio = styled.input.attrs({ type: 'radio' })`
 const StyledRadio = styled.div<{ error?: boolean }>`
   ${HiddenRadioCommon}
   background: #fff;
-  border: 1px solid ${({ error }): string => (error ? colors.error : colors.grayLighten90)};
+  border: 1px solid ${({ error }) => (error ? colors.error : colors.grayLighten90)};
   border-radius: 50%;
   filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.15));
   transition: border 0.2s;

--- a/src/components/spinner/Spinner.tsx
+++ b/src/components/spinner/Spinner.tsx
@@ -26,7 +26,7 @@ const SpinnerPath = styled(Path)<ISpinnerProps>`
   stroke-width: 6;
   stroke-linecap: round;
   stroke-miterlimit: 10;
-  transform: rotate(${({ start }): number => start % 361}deg);
+  transform: rotate(${({ start }) => start % 361}deg);
   transform-origin: 50% 50%;
   animation-fill-mode: forwards;
 
@@ -36,10 +36,10 @@ const SpinnerPath = styled(Path)<ISpinnerProps>`
 
   @keyframes spin {
     from {
-      transform: rotate(${({ start }): number => start % 361}deg);
+      transform: rotate(${({ start }) => start % 361}deg);
     }
     to {
-      transform: rotate(${({ end }): number => end % 361}deg);
+      transform: rotate(${({ end }) => end % 361}deg);
     }
   }
 `;
@@ -49,7 +49,7 @@ interface IProps {
   secondaryColor?: string;
 }
 
-const Spinner: FC<IProps> = ({ primaryColor = colors.primary, secondaryColor = colors.secondary }): JSX.Element => {
+const Spinner: FC<IProps> = ({ primaryColor = colors.primary, secondaryColor = colors.secondary }) => {
   return (
     <SpinnerSVG version="1.1" x="0px" y="0px" viewBox="0 0 50 50">
       <SpinnerPath time={1.4} start={5} end={5} color={secondaryColor} />

--- a/src/components/spinner/Spinner.tsx
+++ b/src/components/spinner/Spinner.tsx
@@ -30,8 +30,8 @@ const SpinnerPath = styled(Path)<ISpinnerProps>`
   transform-origin: 50% 50%;
   animation-fill-mode: forwards;
 
-  stroke: ${({ color }): string => color};
-  animation: ${({ time }): number => time}s spin infinite;
+  stroke: ${({ color }) => color};
+  animation: ${({ time }) => time}s spin infinite;
   animation-timing-function: cubic-bezier(0.43, 0.54, 0.61, 0.74);
 
   @keyframes spin {

--- a/src/components/spinner/SpinnerLogo.tsx
+++ b/src/components/spinner/SpinnerLogo.tsx
@@ -39,7 +39,7 @@ const SpinnerLogo = ({
   primaryColor = colors.officialBlue,
   secondaryColor = colors.officialOrange,
   size = '100px',
-}: SpinnerLogoProps): JSX.Element => (
+}: SpinnerLogoProps) => (
   <SpinnerContainer size={size}>
     <SpinningCircle viewBox="0 0 506 400" fill="none">
       <circle

--- a/src/components/tabs/Tab.tsx
+++ b/src/components/tabs/Tab.tsx
@@ -5,6 +5,6 @@ export interface TabProps {
   children: React.ReactNode;
 }
 
-const Tab: FC<TabProps> = ({ children }: TabProps): JSX.Element => <>{children}</>;
+const Tab: FC<TabProps> = ({ children }: TabProps) => <>{children}</>;
 
 export default Tab;

--- a/src/components/tabs/TabHeader.tsx
+++ b/src/components/tabs/TabHeader.tsx
@@ -8,11 +8,11 @@ interface Props extends HTMLProps<HTMLInputElement> {
 }
 
 const TabHeader = styled.div<Props>`
-  color: ${({ selected }): string => (selected ? colors.primary : colors.grayDarken30)};
+  color: ${({ selected }) => (selected ? colors.primary : colors.grayDarken30)};
   padding: 10px 0;
   transition: color 0.2s;
   font-size: 1.5rem;
-  cursor: ${({ selected }): string | false => !selected && 'pointer'};
+  cursor: ${({ selected }) => !selected && 'pointer'};
 
   &:not(:first-child) {
     border-left: none;

--- a/src/components/tabs/TabSelect.tsx
+++ b/src/components/tabs/TabSelect.tsx
@@ -17,8 +17,8 @@ const dividerHeight = 3;
 const Slider = styled.div<SliderProps>`
   transition: all 0.15s cubic-bezier(0.645, 0.045, 0.355, 1);
   border-top: ${dividerHeight}px solid ${colors.primary};
-  width: ${({ width }): number => width}px;
-  margin-left: ${({ offset }): number => offset}px;
+  width: ${({ width }) => width}px;
+  margin-left: ${({ offset }) => offset}px;
   margin-top: -${dividerHeight}px;
   margin-bottom: 10px;
 `;

--- a/src/components/tabs/TabSelect.tsx
+++ b/src/components/tabs/TabSelect.tsx
@@ -37,13 +37,13 @@ interface Props {
   children: React.ReactNode;
 }
 
-const TabSelect: FC<Props> = ({ activeTab, children, ...rest }: Props): JSX.Element => {
+const TabSelect: FC<Props> = ({ activeTab, children, ...rest }: Props) => {
   const [sliderOffset, setSliderOffset] = useState(0);
   const [sliderWidth, setSliderWidth] = useState(0);
 
   const selectedTab = useRef<HTMLElement>(null);
 
-  useEffect((): void => {
+  useEffect(() => {
     if (selectedTab && selectedTab.current) {
       setSliderOffset(selectedTab.current.offsetLeft);
       setSliderWidth(selectedTab.current.clientWidth);

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -9,7 +9,7 @@ interface Props {
   children: TabElement[] | TabElement;
 }
 
-const Tabs: FC<Props> = ({ children }: Props): JSX.Element => {
+const Tabs: FC<Props> = ({ children }: Props) => {
   const [activeTab, setActiveTab] = useState(0);
 
   return (
@@ -21,7 +21,7 @@ const Tabs: FC<Props> = ({ children }: Props): JSX.Element => {
           }
 
           return (
-            <TabHeader tab={i} onClick={(): void => setActiveTab(i)}>
+            <TabHeader tab={i} onClick={() => setActiveTab(i)}>
               {child.props.title}
             </TabHeader>
           );

--- a/src/components/textField/TextField.tsx
+++ b/src/components/textField/TextField.tsx
@@ -47,7 +47,7 @@ const InputField = styled.input<{ status?: StatusStrings }>`
 
   &:invalid {
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2),
-      inset 0 0 0 1px ${({ status }): string => (status ? statuses[status] : colors.error)};
+      inset 0 0 0 1px ${({ status }) => (status ? statuses[status] : colors.error)};
     box-sizing: border-box;
   }
 
@@ -57,7 +57,7 @@ const InputField = styled.input<{ status?: StatusStrings }>`
 
   &:invalid + p {
     font-size: 0.7em;
-    color: ${({ status }): string => (status ? statuses[status] : colors.error)};
+    color: ${({ status }) => (status ? statuses[status] : colors.error)};
   }
 `;
 
@@ -66,7 +66,7 @@ const InputLabel = styled.label<{ color?: string }>`
   font-weight: bold;
   font-size: 0.75rem;
   margin-bottom: 0.5rem;
-  color: ${({ color }): string => color || colors.primary};
+  color: ${({ color }) => color || colors.primary};
 
   &:empty {
     margin: 0;

--- a/src/components/textField/TextField.tsx
+++ b/src/components/textField/TextField.tsx
@@ -81,13 +81,7 @@ const InputMessage = styled.p`
   }
 `;
 
-const TextField = ({
-  type = 'text',
-  label = '',
-  labelColor = '',
-  errorMessage = '',
-  ...props
-}: TextFieldProps): JSX.Element => {
+const TextField = ({ type = 'text', label = '', labelColor = '', errorMessage = '', ...props }: TextFieldProps) => {
   return (
     <InputContainer>
       <InputLabel color={labelColor}>{label}</InputLabel>
@@ -106,19 +100,19 @@ const ClearButton = styled.button`
   background-color: transparent;
 `;
 
-const ClearableInputField = ({ disabled, ...props }: TextFieldProps): JSX.Element => {
+const ClearableInputField = ({ disabled, ...props }: TextFieldProps) => {
   const [text, setText] = useState(props.defaultValue || '');
   return (
     <div>
       <InputField
         value={text}
-        onChange={(e): void => {
+        onChange={(e) => {
           setText(e.target.value);
         }}
         {...props}
         disabled={disabled}
       />
-      {text && !disabled && <ClearButton onClick={(): void => setText('')}>X</ClearButton>}
+      {text && !disabled && <ClearButton onClick={() => setText('')}>X</ClearButton>}
     </div>
   );
 };

--- a/src/components/toggleSwitch/ToggleSwitch.tsx
+++ b/src/components/toggleSwitch/ToggleSwitch.tsx
@@ -44,13 +44,13 @@ const StyledSlider = styled.div<{ checked?: boolean; size: number; spacing: numb
   transition: left 0.2s;
 
   ${({ checked, size }) =>
-    Boolean(checked) &&
+    checked &&
     css`
       left: calc(100% - ${size}px);
     `}
 `;
 
-const ToggleSwitch = ({ initialChecked = false, disabled = false, size = 16 }: Props): JSX.Element => {
+const ToggleSwitch = ({ initialChecked = false, disabled = false, size = 16 }: Props) => {
   const spacing = size / 8;
   const [checked, setChecked] = useState(initialChecked);
 

--- a/src/components/toggleSwitch/ToggleSwitch.tsx
+++ b/src/components/toggleSwitch/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { colors } from 'common/colors';
 
 import { CircleCheckmark } from 'index';
@@ -17,11 +17,11 @@ const StyledButton = styled.button<{ spacing: number; size: number; disabled: bo
   display: inline-flex;
   align-items: center;
   background: #fff;
-  width: ${({ size }): string => size * 2 + 'px'};
-  height: ${({ size }): string => size + 'px'};
-  padding: ${({ spacing }): string => spacing + 'px'};
-  border: ${({ spacing }): string => spacing + 'px'} solid ${colors.grayLighten60};
-  border-radius: ${({ size, spacing }): string => size + spacing + 'px'};
+  width: ${({ size }) => size * 2 + 'px'};
+  height: ${({ size }) => size + 'px'};
+  padding: ${({ spacing }) => spacing + 'px'};
+  border: ${({ spacing }) => spacing + 'px'} solid ${colors.grayLighten60};
+  border-radius: ${({ size, spacing }) => size + spacing + 'px'};
   box-sizing: content-box;
   cursor: pointer;
 
@@ -29,11 +29,11 @@ const StyledButton = styled.button<{ spacing: number; size: number; disabled: bo
     outline: none;
   }
 
-  ${({ disabled }): string | false =>
+  ${({ disabled }) =>
     disabled &&
-    `
-        background: ${colors.grayLighten90};
-        cursor: not-allowed;
+    css`
+      background: ${colors.grayLighten90};
+      cursor: not-allowed;
     `}
 `;
 
@@ -43,10 +43,10 @@ const StyledSlider = styled.div<{ checked?: boolean; size: number; spacing: numb
   border-radius: 50%;
   transition: left 0.2s;
 
-  ${({ checked, size }): string | false =>
+  ${({ checked, size }) =>
     Boolean(checked) &&
-    `
-        left: calc(100% - ${size}px);
+    css`
+      left: calc(100% - ${size}px);
     `}
 `;
 
@@ -54,9 +54,9 @@ const ToggleSwitch = ({ initialChecked = false, disabled = false, size = 16 }: P
   const spacing = size / 8;
   const [checked, setChecked] = useState(initialChecked);
 
-  function onClick(): void {
-    setChecked(!checked);
-  }
+  const onClick = () => {
+    setChecked((current) => !current);
+  };
 
   return (
     <StyledButton size={size} spacing={spacing} disabled={disabled} onClick={onClick}>


### PR DESCRIPTION
Remove the manually defined return types in styled-component prop functions as they serve no real purpose and are not checked by out linter(s) or anything.