### PR TITLE
Checkbox: Sync state with props to allow for both methods

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled, { css, StyledComponentProps } from 'styled-components';
 import { colors } from 'common/colors';
 import Icon from 'components/icon/Icon';
@@ -17,6 +17,13 @@ const Checkbox = ({ label, isChecked, onChange, disabled, error, ...props }: Che
     setChecked(!checked);
     onChange(checked);
   }
+
+  useEffect(() => {
+    if(isChecked !== checked) {
+      setChecked(isChecked);
+    }
+  }, [isChecked]);
+
   return (
     <CheckboxLabel disabled={disabled}>
       <HiddenCheckbox checked={checked} disabled={disabled} onChange={update} {...props} />


### PR DESCRIPTION
<!-- This template exists to remind you about typical things that are forgotten before posting a PR. Feel free to scrap eveything if it does not fit your way of expressing PRs. -->

# Checklist

- [x] I have ran `yarn lint-check`.
- [ ] I have ran `yarn chromatic` such that other people can review my UI changes at [chromaticqa.com](https://www.chromaticqa.com/builds?appId=5dea690ec744f30020aaf273).
- [ ] I have created a new component.
  - [ ] I have made sure that the component is exported from `./src/index.ts`.
  - [ ] I have created stories for my component.

# Notes to other people

- [ ] I have made global changes. (Global CSS or Storybook itself)
- [ ] I have added new depenencies.

# About the pull request

One can either control a checkbox through `isChecked` or one can allow for the checkbox to update itself and just use the value for what you want.
However, right now, `isChecked` does not work since the state overrides the prop.


## Screenshots

...
