### PR TITLE
Remove lingering radio types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotkomonline/design-system",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/index.modern.mjs",

--- a/src/components/radio/RadioButton.tsx
+++ b/src/components/radio/RadioButton.tsx
@@ -6,8 +6,8 @@ import { RadioProps } from './RadioGroup';
 interface RadioButtonProps extends Omit<RadioProps, 'choices' | 'onChange'> {
   value: string;
   children: React.ReactNode;
-  checked: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  checked?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void; // onChange is supplied through RadioGroup if wrapped on render, so TS fail to see it.
 }
 
 const RadioButton: React.FC<RadioButtonProps> = ({

--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -3,14 +3,7 @@ import styled from 'styled-components';
 import _ from 'lodash';
 import RadioButton from './RadioButton';
 
-interface RadioButtonChoice {
-  value: string;
-  label: React.ReactNode;
-  defaultChecked?: boolean;
-}
-
 export interface RadioProps {
-  choices: RadioButtonChoice[];
   disabled?: boolean;
   groupName?: string;
   error?: boolean;


### PR DESCRIPTION
I forgot to remove some unused types, which were not detected by MDX, but when used in distributed JSX.