### PR TITLE
Move fonts to consumer

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,3 +3,4 @@
     margin: 16px !important;
   }
 </style>
+<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Serif+Pro|Source+Code+Pro|Material+Icons+Outlined" rel="stylesheet">

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ import { Message } from '@dotkomonline/design-system';
 export const SuccessMessage = ({ children }) => <Message type="success">{children}</Message>;
 ```
 
+To get the fonts and icons to work you will also need to include them in the head of your application. In your index.html, or your alternative, include this:
+
+```html
+<link
+  href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Serif+Pro|Source+Code+Pro|Material+Icons+Outlined"
+  rel="stylesheet"
+/>
+```
+
 ## Development
 
 `yarn` to install the dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9373,26 +9373,6 @@
         }
       }
     },
-    "fontsource-material-icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fontsource-material-icons/-/fontsource-material-icons-3.0.2.tgz",
-      "integrity": "sha512-ORJMZBCDDVMt+k5WwKLrsv276u9KGXGWf54+0jX9yLe1L6WaRNeWlgY9Shs8TNzNOkDIpRuBlWptp3QnrBHjSg=="
-    },
-    "fontsource-source-code-pro": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/fontsource-source-code-pro/-/fontsource-source-code-pro-3.0.10.tgz",
-      "integrity": "sha512-O240cr7mUAiiqZZ4pb9tEZyRrmgYpS7qQvrnuS0zXFvHAuLRdl+hbE2RQN+QSQmzovOYIiZpHzX6cME4Phc8YA=="
-    },
-    "fontsource-source-sans-pro": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/fontsource-source-sans-pro/-/fontsource-source-sans-pro-3.0.9.tgz",
-      "integrity": "sha512-kBwOSHXR/P+oTGCdemcJM9Z7jYK1O0h+aeqq60fajP/HvhYJWTVBA1ZmKlOX+rHPARLRgfwCv6B4m1UC7bHsoA=="
-    },
-    "fontsource-source-serif-pro": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/fontsource-source-serif-pro/-/fontsource-source-serif-pro-3.0.10.tgz",
-      "integrity": "sha512-LhIcets0YtBS56iea5P7kt+3z9V9NaavJdZKXW9anLybg2nxwUuHE6JLRv6mHwjMEa7DPz+ak6DLgBrBTvTHFw=="
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,6 @@
     "@storybook/addons": "^5.3.12",
     "@storybook/react": "^5.3.12",
     "@storybook/source-loader": "^5.3.12",
-    "@types/lodash": "^4.14.161",
-    "fontsource-material-icons": "^3.0.2",
-    "fontsource-source-code-pro": "^3.0.10",
-    "fontsource-source-sans-pro": "^3.0.9",
-    "fontsource-source-serif-pro": "^3.0.10"
+    "@types/lodash": "^4.14.161"
   }
 }

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -1,12 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 import Reset from './reset';
 import { media, breakPointsInPX } from './layout';
-import 'fontsource-material-icons/outlined.css';
-import 'fontsource-source-sans-pro/300.css';
-import 'fontsource-source-sans-pro/400.css';
-import 'fontsource-source-sans-pro/700.css';
-import 'fontsource-source-serif-pro';
-import 'fontsource-source-code-pro';
 
 export const GlobalStyle = createGlobalStyle`
   ${Reset}

--- a/src/components/fonts/fonts.stories.mdx
+++ b/src/components/fonts/fonts.stories.mdx
@@ -1,0 +1,12 @@
+<Meta title="Fonts" />
+
+# Fonts
+
+To use fonts and icons from the design system you must include them in your applications head. In your index.html or similar include this:
+
+```html
+<link
+  href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Serif+Pro|Source+Code+Pro|Material+Icons+Outlined"
+  rel="stylesheet"
+/>
+```

--- a/src/components/icon/Icon.stories.mdx
+++ b/src/components/icon/Icon.stories.mdx
@@ -20,6 +20,8 @@ You can find all the different icons [here](https://material.io/resources/icons/
 
 When you follow the link above, you can find an icon you like, then enter the name of the icon into this component. The icons inherit color and font-size from its parents, allowing you to easily style the icons.
 
+PS: for the icons to work you must remember to inlcude the fonts in your document head.
+
 <Preview>
   <Story name="All">
     <ExampleIconContainer>

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -14,7 +14,7 @@ const StyledIcon = styled.i`
 
 const Icon = ({ name, className = '', ...props }: IconProps) => {
   return (
-    <StyledIcon className={`material-icons ${className}`} {...props}>
+    <StyledIcon className={`material-icons-outlined ${className}`} {...props}>
       {name}
     </StyledIcon>
   );


### PR DESCRIPTION
My previous solution for including fonts didn't actually work in production. We've decided that the cleanest way we know of doing this is to move the include to the consumer repository. 