### PR TITLE
Select props typedefining 

### DIFF
--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -3,8 +3,12 @@ import ReactSelect from 'react-select';
 import styled, { StyledComponentProps } from 'styled-components';
 import { colors } from 'common/colors';
 
+interface OptionType {
+  value: string;
+  label: string;
+}
 interface SelectProps extends StyledComponentProps<'select', any, any, any> {
-  options: [{ value: any; label: any }];
+  options: OptionType[];
 }
 
 const StyledSelect = styled(ReactSelect)`

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -4,8 +4,8 @@ import styled, { StyledComponentProps } from 'styled-components';
 import { colors } from 'common/colors';
 
 interface OptionType {
-  value: string;
-  label: string;
+  value: any;
+  label: any;
 }
 interface SelectProps extends StyledComponentProps<'select', any, any, any> {
   options: OptionType[];


### PR DESCRIPTION
<!-- This template exists to remind you about typical things that are forgotten before posting a PR. Feel free to scrap eveything if it does not fit your way of expressing PRs. -->

# Checklist

- [x] I have ran `yarn lint-check`.
- [ ] I have ran `yarn chromatic` such that other people can review my UI changes at [chromaticqa.com](https://www.chromaticqa.com/builds?appId=5dea690ec744f30020aaf273). *clould not get running/ need code*
- [ ] I have created a new component.
  - [ ] I have made sure that the component is exported from `./src/index.ts`.
  - [ ] I have created stories for my component.

# Notes to other people

- [ ] I have made global changes. (Global CSS or Storybook itself)
- [ ] I have added new depenencies.

# About the pull request
Moved out the interface of OptiontType
Changed options to an array and not a touple corresponding to what react-select expects. ref: https://react-select.com/props

not 100% sure about the changes, but i fixed a bug in my project (i might just be stupid)

...

## Screenshots

...
